### PR TITLE
remove unused function which is actually also removed from scipy

### DIFF
--- a/biot_savart/biot_savart.py
+++ b/biot_savart/biot_savart.py
@@ -10,7 +10,7 @@ All lengths are in cm, B-field is in G
 
 import numpy as np
 from .inputs import parse_coil
-from scipy.integrate import simpson, trapz
+from scipy.integrate import simpson
 
 '''
 Feature Wishlist:


### PR DESCRIPTION
Scipy has removed `trapz` from integrate module and now we need to use `trapezoid `.